### PR TITLE
Item page fixes

### DIFF
--- a/src/components/UI/molecules/ArtistCard/index.tsx
+++ b/src/components/UI/molecules/ArtistCard/index.tsx
@@ -16,25 +16,17 @@ interface ArtistProps {
 const ArtistCard = ({ artist, className }: ArtistProps) => {
   const ipfsBaseUrl = getAppConfig().ipfs.baseUrl;
   const isLight = true;
-  const { nfts, images } = useNftContext();
+  const { nfts } = useNftContext();
 
-  const getImages = (artistNfts: Nft[] | undefined) => {
-    if (!artistNfts) return [];
-
-    const random = Math.floor(Math.random() * artistNfts.length);
-    return images.list.filter(
-      (image) => image.ipfsHash === artistNfts[random]?.ipfsHash
-    );
-  };
-  const artistNfts = nfts.getByPubKeyHash(artist.pubKeyHash);
-  const artistImages = useMemo(() => getImages(artistNfts), [artistNfts]);
+  const artistNfts = nfts.getByPubKeyHash(artist.pubKeyHash) ?? [];
+  const nft = artistNfts[Math.floor(Math.random() * artistNfts.length)];
 
   return (
     <Link to={`artist/${artist.id}`}>
       <Box
         boxClass={classNames(styles.container, className)}
         style={{
-          backgroundImage: `url(${ipfsBaseUrl}${artistImages[0]?.ipfsHash})`,
+          backgroundImage: `url(${ipfsBaseUrl}${nft?.ipfsHash})`,
         }}
       >
         <h4

--- a/src/pages/ItemPage/index.tsx
+++ b/src/pages/ItemPage/index.tsx
@@ -104,7 +104,7 @@ const ItemPage = ({ type }: Props) => {
     <>
       <div className={styles.container}>
         <ItemPhotoCard
-          imageUrl={`${getAppConfig().ipfs.baseUrl}${image?.ipfsHash}`}
+          imageUrl={`${getAppConfig().ipfs.baseUrl}${nft?.ipfsHash}`}
           likeCount="167"
         />
         <div className={styles['item-details-container']}>

--- a/src/pages/ItemPage/index.tsx
+++ b/src/pages/ItemPage/index.tsx
@@ -8,6 +8,7 @@ import { useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { getAppConfig } from 'utils/appConfig';
 import { priceToADA } from 'utils/priceToADA';
+import { roundToFixed } from 'utils/roundToFixed';
 import BuyModal from '../../components/UI/organisms/ItemPage/BuyModal';
 import SetPriceModal from '../../components/UI/organisms/ItemPage/SetPriceModal';
 import styles from './index.module.scss';
@@ -52,11 +53,13 @@ const ItemPage = ({ type }: Props) => {
     if (!nft || !image) common.fetchAll();
   }, []);
 
-  const shareToFloat = (share: bigint, decimals: number) => {
-    const sharePercent = Number(share) / 10000;
-    const multiplier = 10 ** decimals;
+  const shareToPercentRoyalties = (share?: bigint) => {
+    if (!share) return '';
 
-    return Math.round(sharePercent * multiplier) / multiplier;
+    // Convert share from fraction of 10000 to fraction of 100
+    const sharePercent = Number(share) / 100;
+
+    return `${roundToFixed(sharePercent, 2)}% royalties`;
   };
 
   const closeModal = () => setDisplayModal('NONE');
@@ -113,11 +116,7 @@ const ItemPage = ({ type }: Props) => {
             saleValue={priceToADA(nft?.metadata.ownerPrice)}
             topBidValue=""
             description={image?.description ?? ''}
-            creatorValue={`${
-              nft?.metadata.authorShare
-                ? shareToFloat(nft?.metadata.authorShare, 2)
-                : 0
-            }% royalties`}
+            creatorValue={shareToPercentRoyalties(nft?.metadata.authorShare)}
             creatorName={artist?.name ?? ''}
             creatorImagePath={artist?.imagePath}
             ownerPKH={owner?.pubKeyHash ?? ''}

--- a/src/utils/roundToFixed.ts
+++ b/src/utils/roundToFixed.ts
@@ -1,0 +1,7 @@
+/**
+ * Rounds the provided number to a fixed number of decimal places.
+ */
+export const roundToFixed = (num: number, decimals: number) => {
+  const multiplier = 10 ** decimals;
+  return Math.round(num * multiplier) / multiplier;
+};


### PR DESCRIPTION
## Changes:
- Use `ipfsHash` directly from NFT metadata instead of relying on image data from backend
- Fix display of royalty percentage (was off by factor of 10)